### PR TITLE
Update to diagrams-lib-0.7

### DIFF
--- a/diagrams-opengl.cabal
+++ b/diagrams-opengl.cabal
@@ -42,9 +42,9 @@ Library
   Build-depends:       base          >= 4.3   && < 4.7
                      , vector-space  >= 0.7   && < 0.9
                      , colour
-                     , diagrams-core >= 0.6.1   && < 0.7
-                     , diagrams-lib  >= 0.6   && < 0.7
-                     , monoid-extras >= 0.2   && < 0.3
+                     , diagrams-core >= 0.7   && < 0.8
+                     , diagrams-lib  >= 0.7   && < 0.8
+                     , monoid-extras >= 0.3   && < 0.4
                      , cmdargs       >= 0.6   && < 0.11
                      , OpenGL        >= 2.6   && < 2.9
                      , vector        >= 0.10  && < 0.11

--- a/examples/lines.hs
+++ b/examples/lines.hs
@@ -15,11 +15,13 @@ v2 = r2 (0.5,-0.5)
 p :: Path R2
 p = fromOffsets [v1,v2, v1, v2,v1,-v2,v1]
 
-p2_ :: Path R2
-p2_ = fromOffsets [v2, v1]
+p2_, p2_closed :: Path R2
+[p2_, p2_closed] = map pathFromTrail [open, closed]
+ where open = fromOffsets [v2, v1]
+       closed = closeTrail open
 
 d :: Diagram OpenGL R2
 d = stroke p # lc red <>
     stroke p2_ # lc blue <>
     (stroke $ fromOffsets [v2, v2, v1]) <>
-    stroke (close p2_) # lc green # translate (v1+v2)
+    stroke (p2_closed) # lc green # translate (v1+v2)

--- a/examples/polygons.hs
+++ b/examples/polygons.hs
@@ -4,7 +4,6 @@ import Diagrams.Backend.OpenGL.CmdLine
 
 main :: IO ()
 main = do
-  putStrLn $ show $ renderPath p
   defaultMain d
 
 v1 :: R2
@@ -14,10 +13,10 @@ v2 :: R2
 v2 = r2 (0.5,-0.5)
 
 p :: Path R2
-p = close $ fromOffsets [v1,v2]
+p = pathFromTrail . closeTrail $ fromOffsets [v1,v2]
 
 p2_ :: Path R2
-p2_ = close $ fromOffsets [v2, v1]
+p2_ = pathFromTrail . closeTrail $ fromOffsets [v2, v1]
 
 d :: Diagram OpenGL R2
 d = stroke p  # fc green <>


### PR DESCRIPTION
`diagrams-lib` has between `0.6` and `0.7` changed in two points relevant to this package:
- To get a "concrete location" trail / segment / etc., you previously had to pair it as `(Point, Thing)`. There is now [the `Located` type constructor](http://hackage.haskell.org/packages/archive/diagrams-lib/latest/doc/html/Diagrams-Located.html#t:Located) which handles this in a better way.
- Trails are now not a simple union ADT with `Loop` and `Line` constructors anymore, but [a GADT wrapper around a type-indexed `Trail' Closed` or `Trail' Open` type](http://hackage.haskell.org/packages/archive/diagrams-lib/latest/doc/html/Diagrams-Trail.html#v:Trail).

Both changes brake this backend package. I adopted it so it works with the new API. It is, however, now not compatible to `diagrams-lib-0.6` anymore.
